### PR TITLE
2016 -> 2017

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
 	</div>
 
      <div id="footer">
-         <p>Copyright © 2002-2016 <a href="mailto:jvinet@zeroflux.org"
+         <p>Copyright © 2002-2017 <a href="mailto:jvinet@zeroflux.org"
              title="Contact Judd Vinet">Judd Vinet</a> and <a href="mailto:aaron@archlinux.org"
              title="Contact Aaron Griffin">Aaron Griffin</a>.</p>
 


### PR DESCRIPTION
Updated "2016" in the footer to "2017", to match current year and mirror the way it is written on official https://www.archlinux.org/ page.